### PR TITLE
Fix three grave threading problems: (1) CreateThread in C code; (2) u…

### DIFF
--- a/win/tclWinSock.c
+++ b/win/tclWinSock.c
@@ -2374,8 +2374,11 @@ InitSockets(void)
     if (tsdPtr->socketListLock == NULL) {
 	goto initFailure;
     }
-    tsdPtr->socketThread = CreateThread(NULL, 256, SocketThread, tsdPtr, 0,
-	    &id);
+#if defined(_MSC_VER) || defined(__MSVCRT__) || defined(__BORLANDC__)
+    tsdPtr->socketThread = (HANDLE) _beginthreadex(NULL, 256, SocketThread, tsdPtr, 0, &id);
+#else
+    tsdPtr->socketThread = CreateThread(NULL, 256, SocketThread, tsdPtr, 0, &id);
+#endif
     if (tsdPtr->socketThread == NULL) {
 	goto initFailure;
     }

--- a/win/tclWinTime.c
+++ b/win/tclWinTime.c
@@ -372,10 +372,12 @@ NativeGetTime(
 		InitializeCriticalSection(&timeInfo.cs);
 		timeInfo.readyEvent = CreateEvent(NULL, FALSE, FALSE, NULL);
 		timeInfo.exitEvent = CreateEvent(NULL, FALSE, FALSE, NULL);
-		timeInfo.calibrationThread = CreateThread(NULL, 256,
-			CalibrationThread, (LPVOID) NULL, 0, &id);
-		SetThreadPriority(timeInfo.calibrationThread,
-			THREAD_PRIORITY_HIGHEST);
+#if defined(_MSC_VER) || defined(__MSVCRT__) || defined(__BORLANDC__)
+		timeInfo.calibrationThread = (HANDLE) _beginthreadex(NULL, 256, CalibrationThread, NULL, 0, &id);
+#else
+		timeInfo.calibrationThread = CreateThread(NULL, 256, CalibrationThread, NULL, 0, &id);
+#endif
+		SetThreadPriority(timeInfo.calibrationThread, THREAD_PRIORITY_HIGHEST);
 
 		/*
 		 * Wait for the thread just launched to start running, and


### PR DESCRIPTION
…se of GetExitCodeThread; (3) use of TerminateThread

For (1), please refer to
http://www.flounder.com/badprogram.htm#CreateThread

For (2), see http://www.flounder.com/badprogram.htm#Polling

For (3), see MSDN and an old article from Jeffrey Richter on the
Microsoft Systems Journal in March 1996 currently available at:
https://www.microsoft.com/msj/archive/SFFF.aspx

Original code caused grave intermittent crashes that appear to be
completely cured by this fix.