### PR TITLE
add github workflow for CYGWIN-like platform MSYS2 on Windows

### DIFF
--- a/.github/workflows/msys2-build.yml
+++ b/.github/workflows/msys2-build.yml
@@ -1,0 +1,33 @@
+name: msys2
+
+on:
+  push:
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    defaults:
+      run:
+        shell: msys2 {0}
+        working-directory: unix
+
+    steps:
+      - name: Init MSYS
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: MSYS
+          install: git base-devel msys2-devel zlib
+          update: true
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build
+        run: |
+          autoreconf -vfi
+          ./configure -C --prefix=/usr --enable-64bit || { cat config.log; cat config.cache; exit 1; }
+          make
+      - name: Run Tests (ignoring test io-53.4.1 which hangs)
+        run: make test
+        env:
+          ERROR_ON_FAILURES: 1
+          TESTFLAGS: -skip io-53.4.1 -verbose bpsel

--- a/tests/env.test
+++ b/tests/env.test
@@ -107,6 +107,7 @@ variable keep {
     CommonProgramFiles CommonProgramFiles(x86) ProgramFiles
     ProgramFiles(x86) CommonProgramW6432 ProgramW6432
     WINECONFIGDIR WINEDATADIR WINEDLLDIR0 WINEHOMEDIR
+    MSYSTEM
 }
 
 variable printenvScript [makeFile [string map [list @keep@ [list $keep]] {

--- a/unix/Makefile.in
+++ b/unix/Makefile.in
@@ -798,9 +798,6 @@ ${LIB_FILE}: ${STUB_LIB_FILE} ${OBJS} ${TCL_ZIP_FILE}
 	fi
 
 ${STUB_LIB_FILE}: ${STUB_LIB_OBJS}
-	@if [ "x${LIB_FILE}" = "xlibtcl${MAJOR_VERSION}.${MINOR_VERSION}.dll" ] ; then \
-	    ( cd ${TOP_DIR}/win; ${MAKE} winextensions ); \
-	fi
 	rm -f $@
 	@MAKE_STUB_LIB@
 

--- a/unix/configure
+++ b/unix/configure
@@ -4484,14 +4484,6 @@ else
   tcl_ok=yes
 fi
 
-
-    if test "${enable_shared+set}" = set; then
-	enableval="$enable_shared"
-	tcl_ok=$enableval
-    else
-	tcl_ok=yes
-    fi
-
     if test "$tcl_ok" = "yes" ; then
 	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: shared" >&5
 $as_echo "shared" >&6; }

--- a/unix/configure
+++ b/unix/configure
@@ -5310,7 +5310,7 @@ fi
 	    CC_SEARCH_FLAGS=""
 	    LD_SEARCH_FLAGS=""
 	    ;;
-	CYGWIN_*)
+	CYGWIN_*|MSYS_*)
 	    SHLIB_CFLAGS="-fno-common"
 	    SHLIB_LD='${CC} -shared'
 	    SHLIB_SUFFIX=".dll"
@@ -6559,7 +6559,7 @@ fi
 	case $system in
 	    AIX-*) ;;
 	    BSD/OS*) ;;
-	    CYGWIN_*) ;;
+	    CYGWIN_*|MSYS_*) ;;
 	    HP_UX*) ;;
 	    Darwin-*) ;;
 	    IRIX*) ;;

--- a/unix/configure
+++ b/unix/configure
@@ -5348,7 +5348,31 @@ $as_echo "$ac_cv_cygwin" >&6; }
 	    if test "$ac_cv_cygwin" = "no"; then
 		as_fn_error $? "${CC} is not a cygwin compiler." "$LINENO" 5
 	    fi
-	    do64bit_ok=yes
+		{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether CYGWIN platform is 64-bit" >&5
+$as_echo_n "checking whether CYGWIN platform is 64-bit... " >&6; }
+		cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <stdint.h>
+					#if INTPTR_MAX == INT64_MAX
+						#error 64-bit platform
+					#endif
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  do64bit_ok=no
+else
+  do64bit_ok=yes
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+		{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $do64bit_ok" >&5
+$as_echo "$do64bit_ok" >&6; }
 	    ;;
 	dgux*)
 	    SHLIB_CFLAGS="-K PIC"

--- a/unix/configure
+++ b/unix/configure
@@ -5349,15 +5349,6 @@ $as_echo "$ac_cv_cygwin" >&6; }
 		as_fn_error $? "${CC} is not a cygwin compiler." "$LINENO" 5
 	    fi
 	    do64bit_ok=yes
-	    if test "x${SHARED_BUILD}" = "x1"; then
-		echo "running cd ../win; ${CONFIG_SHELL-/bin/sh} ./configure $ac_configure_args"
-		# The eval makes quoting arguments work.
-		if cd ../win; eval ${CONFIG_SHELL-/bin/sh} ./configure $ac_configure_args; cd ../unix
-		then :
-		else
-		    { echo "configure: error: configure failed for ../win" 1>&2; exit 1; }
-		fi
-	    fi
 	    ;;
 	dgux*)
 	    SHLIB_CFLAGS="-K PIC"

--- a/unix/tcl.m4
+++ b/unix/tcl.m4
@@ -1103,15 +1103,6 @@ AC_DEFUN([SC_CONFIG_CFLAGS], [
 		AC_MSG_ERROR([${CC} is not a cygwin compiler.])
 	    fi
 	    do64bit_ok=yes
-	    if test "x${SHARED_BUILD}" = "x1"; then
-		echo "running cd ../win; ${CONFIG_SHELL-/bin/sh} ./configure $ac_configure_args"
-		# The eval makes quoting arguments work.
-		if cd ../win; eval ${CONFIG_SHELL-/bin/sh} ./configure $ac_configure_args; cd ../unix
-		then :
-		else
-		    { echo "configure: error: configure failed for ../win" 1>&2; exit 1; }
-		fi
-	    fi
 	    ;;
 	dgux*)
 	    SHLIB_CFLAGS="-K PIC"

--- a/unix/tcl.m4
+++ b/unix/tcl.m4
@@ -1083,7 +1083,7 @@ AC_DEFUN([SC_CONFIG_CFLAGS], [
 	    CC_SEARCH_FLAGS=""
 	    LD_SEARCH_FLAGS=""
 	    ;;
-	CYGWIN_*)
+	CYGWIN_*|MSYS_*)
 	    SHLIB_CFLAGS="-fno-common"
 	    SHLIB_LD='${CC} -shared'
 	    SHLIB_SUFFIX=".dll"
@@ -1783,7 +1783,7 @@ dnl # preprocessing tests use only CPPFLAGS.
 	case $system in
 	    AIX-*) ;;
 	    BSD/OS*) ;;
-	    CYGWIN_*) ;;
+	    CYGWIN_*|MSYS_*) ;;
 	    HP_UX*) ;;
 	    Darwin-*) ;;
 	    IRIX*) ;;

--- a/unix/tcl.m4
+++ b/unix/tcl.m4
@@ -512,13 +512,6 @@ AC_DEFUN([SC_ENABLE_SHARED], [
 	    [build and link with shared libraries (default: on)]),
 	[tcl_ok=$enableval], [tcl_ok=yes])
 
-    if test "${enable_shared+set}" = set; then
-	enableval="$enable_shared"
-	tcl_ok=$enableval
-    else
-	tcl_ok=yes
-    fi
-
     if test "$tcl_ok" = "yes" ; then
 	AC_MSG_RESULT([shared])
 	SHARED_BUILD=1

--- a/unix/tcl.m4
+++ b/unix/tcl.m4
@@ -1102,7 +1102,16 @@ AC_DEFUN([SC_CONFIG_CFLAGS], [
 	    if test "$ac_cv_cygwin" = "no"; then
 		AC_MSG_ERROR([${CC} is not a cygwin compiler.])
 	    fi
-	    do64bit_ok=yes
+		AC_MSG_CHECKING([whether CYGWIN platform is 64-bit])
+		AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
+				[[#include <stdint.h>
+					#if INTPTR_MAX == INT64_MAX
+						#error 64-bit platform
+					#endif
+				]],[])],
+				[do64bit_ok=no],
+				[do64bit_ok=yes])
+		AC_MSG_RESULT([$do64bit_ok])
 	    ;;
 	dgux*)
 	    SHLIB_CFLAGS="-K PIC"

--- a/win/configure
+++ b/win/configure
@@ -3767,14 +3767,6 @@ else
   tcl_ok=yes
 fi
 
-
-    if test "${enable_shared+set}" = set; then
-	enableval="$enable_shared"
-	tcl_ok=$enableval
-    else
-	tcl_ok=yes
-    fi
-
     if test "$tcl_ok" = "yes" ; then
 	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: shared" >&5
 $as_echo "shared" >&6; }

--- a/win/tcl.m4
+++ b/win/tcl.m4
@@ -359,13 +359,6 @@ AC_DEFUN([SC_ENABLE_SHARED], [
 	[  --enable-shared         build and link with shared libraries (default: on)],
 	[tcl_ok=$enableval], [tcl_ok=yes])
 
-    if test "${enable_shared+set}" = set; then
-	enableval="$enable_shared"
-	tcl_ok=$enableval
-    else
-	tcl_ok=yes
-    fi
-
     if test "$tcl_ok" = "yes" ; then
 	AC_MSG_RESULT([shared])
 	SHARED_BUILD=1


### PR DESCRIPTION
This commit series serves the purpose to prepare for and add a github workflow for MSYS(2), a CYGWIN-like environment on Windows.  It compiles fine, but reveals many test failures to be fixed.

NB:
* The entanglement with the `win` dir appears to be unneccassary and thus is removed to allow a pure `unix` configuration and build for MSYS and CYGWIN.
* As of now there are many failing tests, while one test (io-53.4.1) is omitted since it hangs as of now.
* For reference as to how [CYGWIN](https://cygwin.com/git-cygwin-packages/?p=git/cygwin-packages/tcl.git;a=tree) and [MSYS2](https://github.com/msys2/MSYS2-packages/tree/master/tcl) see need for heavily patching the tcl package which effectively ignore most of the `#ifdef __CYGWIN__` branches.  I believe that MSYS2 mostly relies on the CYGWIN patch.
* The msys2 workflow file added by the top of this branch is meant to be copied to the windows workflow (after testing) 

I hope it is OK that this is a Github PR since this is about a github workflow which should be automatically triggered when opening this PR.