### PR TITLE
add a separate target for nmakehlp to help with cross-compilation

### DIFF
--- a/win/rules.vc
+++ b/win/rules.vc
@@ -548,9 +548,19 @@ NMAKEHLPC = $(_TCLDIR)\win\nmakehlp.c
 
 !endif # NMAKEHLPC
 
+nmakehlp:
+	$(cc32) -nologo "$(NMAKEHLPC)" -link -subsystem:console
+
+# Skip building nmakehlp if flag is set to TRUE
+!if "$(SKIP_NMAKEHLP)" == ""
+SKIP_NMAKEHLP = FALSE
+!endif
+
 # We always build nmakehlp even if it exists since we do not know
 # what source it was built from.
+!if "$(SKIP_NMAKEHLP)" == "FALSE"
 !if [$(cc32) -nologo "$(NMAKEHLPC)" -link -subsystem:console > nul]
+!endif
 !endif
 
 ################################################################


### PR DESCRIPTION
This would enable cross-compilation with the following steps.

1. Setup toolchain environment for the host architecture
2. Compile nmakehlp.exe `nmake -f makefile.vc nmakehlp`
3. Setup toolchain environment for the target architecture
4. Compile tcl with SKIP_NMAKEHLP `nmake -f makefile.vc SKIP_NMAKEHLP=TRUE all`