### PR TITLE
Avoid explicit nmakehlp build step for x86 target for cross-compilation

### DIFF
--- a/win/rules.vc
+++ b/win/rules.vc
@@ -553,7 +553,7 @@ nmakehlp:
 
 # We always build nmakehlp even if it exists since we do not know
 # what source it was built from.
-!if "$(MACHINE)" == "$(NATIVE_ARCH)"
+!if "$(MACHINE)" == "IX86" || "$(MACHINE)" == "$(NATIVE_ARCH)"
 !if [$(cc32) -nologo "$(NMAKEHLPC)" -link -subsystem:console > nul]
 !endif
 !endif


### PR DESCRIPTION
x86 binaries can be run on all architectures so to simplify the compilation we can safely build nmakehlp.exe and avoid requiring explicit nmakehlp build step.

