### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -1,5 +1,8 @@
 name: Linux
 on: [push]
+permissions:
+  contents: read
+
 jobs:
   gcc:
     runs-on: ubuntu-20.04

--- a/.github/workflows/mac-build.yml
+++ b/.github/workflows/mac-build.yml
@@ -1,5 +1,8 @@
 name: macOS
 on: [push]
+permissions:
+  contents: read
+
 jobs:
   xcode:
     runs-on: macos-11

--- a/.github/workflows/onefiledist.yml
+++ b/.github/workflows/onefiledist.yml
@@ -1,5 +1,8 @@
 name: Build Binaries
 on: [push]
+permissions:
+  contents: read
+
 jobs:
   linux:
     name: Linux

--- a/.github/workflows/win-build.yml
+++ b/.github/workflows/win-build.yml
@@ -2,6 +2,9 @@ name: Windows
 on: [push]
 env:
   ERROR_ON_FAILURES: 1
+permissions:
+  contents: read
+
 jobs:
   msvc:
     runs-on: windows-2022


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>
